### PR TITLE
Update to more consistent naming

### DIFF
--- a/src/components/Activity/ActivityContainer.tsx
+++ b/src/components/Activity/ActivityContainer.tsx
@@ -1,6 +1,6 @@
 import { h } from "preact";
 
-export function ActivityContainer() {
+const ActivityContainer = () => {
   return (
     <div
       id="activitiesContainer"
@@ -9,4 +9,6 @@ export function ActivityContainer() {
       <h3 id="activitiesHeader">Activities</h3>
     </div>
   );
-}
+};
+
+export default ActivityContainer;

--- a/src/components/ActivityItem/ActivityItemContainer.tsx
+++ b/src/components/ActivityItem/ActivityItemContainer.tsx
@@ -2,9 +2,9 @@ import { h } from "preact";
 
 type Props = {
   activity?: string;
-} 
+};
 
-export function ActivityItemContainer(props:Props) {
+const ActivityItemContainer = (props: Props) => {
   return (
     <div id="activityItemsContainer" class="oj-flex-item oj-md-6 oj-sm-12">
       <div id="container">
@@ -13,4 +13,6 @@ export function ActivityItemContainer(props:Props) {
       </div>
     </div>
   );
-}
+};
+
+export default ActivityItemContainer;

--- a/src/components/Content/Content.tsx
+++ b/src/components/Content/Content.tsx
@@ -1,11 +1,11 @@
+import ParentContainer1 from "../ParentContainer1";
 import { h } from "preact";
-import {ParentContainer1} from "../ParentContainer1";
 
 export function Content() {
   return (
     <div class="oj-web-applayout-max-width oj-web-applayout-content">
       <h1>Product Information</h1>
-      <ParentContainer1/>
+      <ParentContainer1 />
     </div>
   );
 }

--- a/src/components/ItemDetail/ItemDetailContainer.tsx
+++ b/src/components/ItemDetail/ItemDetailContainer.tsx
@@ -1,10 +1,10 @@
 import { h } from "preact";
 
 type Props = {
-  item?:string;
-}
+  item?: string;
+};
 
-export function ItemDetailContainer(props:Props) {
+const ItemDetailContainer = (props: Props) => {
   return (
     <div
       id="itemDetailsContainer"
@@ -14,4 +14,6 @@ export function ItemDetailContainer(props:Props) {
       {props.item}
     </div>
   );
-}
+};
+
+export default ItemDetailContainer;

--- a/src/components/ParentContainer1.tsx
+++ b/src/components/ParentContainer1.tsx
@@ -1,12 +1,12 @@
+import ActivityContainer from "./Activity/ActivityContainer";
+import ParentContainer2 from "./ParentContainer2";
 import { h } from "preact";
-import { ActivityContainer } from "./Activity/ActivityContainer";
-import { ParentContainer2 } from "./ParentContainer2";
 
 let activitySelected: boolean;
 let activity: string;
 let selectedItem: string;
 
-export function ParentContainer1() {
+const ParentContainer1 = () => {
   activitySelected = true;
   selectedItem = "soccer";
   return (
@@ -15,7 +15,9 @@ export function ParentContainer1() {
       class="oj-flex oj-flex-init oj-panel oj-bg-warning-20"
     >
       <ActivityContainer />
-     { activitySelected && <ParentContainer2 activity={selectedItem}/> }
+      {activitySelected && <ParentContainer2 activity={selectedItem} />}
     </div>
   );
-}
+};
+
+export default ParentContainer1;

--- a/src/components/ParentContainer2.tsx
+++ b/src/components/ParentContainer2.tsx
@@ -1,22 +1,24 @@
+import ActivityItemContainer from "./ActivityItem/ActivityItemContainer";
+import ItemDetailContainer from "./ItemDetail/ItemDetailContainer";
 import { h } from "preact";
-import { ActivityItemContainer } from "./ActivityItem/ActivityItemContainer";
-import { ItemDetailContainer } from "./ItemDetail/ItemDetailContainer";
 
 type Props = {
   activity: string;
-}
+};
 
 let itemSelected: string;
 
-export function ParentContainer2(props:Props) {
-  itemSelected = 'gloves'
+const ParentContainer2 = (props: Props) => {
+  itemSelected = "gloves";
   return (
     <div
       id="parentContainer2"
       class="oj-flex oj-flex-item oj-panel oj-bg-danger-30 oj-lg-padding-6x oj-md-8 oj-sm-12"
     >
       <ActivityItemContainer activity={props.activity} />
-      { itemSelected && <ItemDetailContainer item={itemSelected} />}
+      {itemSelected && <ItemDetailContainer item={itemSelected} />}
     </div>
   );
-}
+};
+
+export default ParentContainer2;

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,29 +1,28 @@
-import { customElement, ExtendGlobalProps } from "ojs/ojvcomponent";
-import { h, Component, ComponentChild } from "preact";
+import { Component, ComponentChild, h } from "preact";
+import { ExtendGlobalProps, customElement } from "ojs/ojvcomponent";
+
+import { Content } from "./Content/Content";
+import Footer from "./Footer";
+import Header from "./Header";
+
 import Context = require("ojs/ojcontext");
-import { Footer } from "./footer";
-import { Header } from "./header";
-import { Content } from "./content/index";
 
 type Props = {
   appName?: string;
   userLogin?: string;
-}
+};
 
 @customElement("app-root")
 export class App extends Component<ExtendGlobalProps<Props>> {
   static defaultProps: Props = {
-    appName: 'Learning Path VDOM',
-    userLogin: "john.hancock@oracle.com"
+    appName: "Learning Path VDOM",
+    userLogin: "john.hancock@oracle.com",
   };
 
   render(props: ExtendGlobalProps<Props>): ComponentChild {
     return (
       <div id="appContainer" class="oj-web-applayout-page">
-        <Header
-          appName={props.appName} 
-          userLogin={props.userLogin} 
-        />
+        <Header appName={props.appName} userLogin={props.userLogin} />
         <Content />
         <Footer />
       </div>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,44 +1,44 @@
 import { h } from "preact";
 
 type Props = {
-  links?: FooterLink[]
-}
+  links?: FooterLink[];
+};
 
 type FooterLink = {
   name: string;
   linkId: string;
   linkTarget: string;
-}
+};
 
 const _DEFAULT_LINKS: FooterLink[] = [
   {
     name: "About Oracle",
     linkId: "aboutOracle",
-    linkTarget: "http://www.oracle.com/us/corporate/index.html#menu-about"
+    linkTarget: "http://www.oracle.com/us/corporate/index.html#menu-about",
   },
   {
     name: "Contact Us",
     linkId: "contactUs",
-    linkTarget: "http://www.oracle.com/us/corporate/contact/index.html"
+    linkTarget: "http://www.oracle.com/us/corporate/contact/index.html",
   },
   {
     name: "Legal Notices",
     linkId: "legalNotices",
-    linkTarget: "http://www.oracle.com/us/legal/index.html"
+    linkTarget: "http://www.oracle.com/us/legal/index.html",
   },
   {
     name: "Terms Of Use",
     linkId: "termsOfUse",
-    linkTarget: "http://www.oracle.com/us/legal/terms/index.html"
+    linkTarget: "http://www.oracle.com/us/legal/terms/index.html",
   },
   {
     name: "Your Privacy Rights",
     linkId: "yourPrivacyRights",
-    linkTarget: "http://www.oracle.com/us/legal/privacy/index.html"
-  }
-]
+    linkTarget: "http://www.oracle.com/us/legal/privacy/index.html",
+  },
+];
 
-export function Footer({ links = _DEFAULT_LINKS } : Props ) {
+const Footer = ({ links = _DEFAULT_LINKS }: Props) => {
   return (
     <footer class="oj-web-applayout-footer" role="contentinfo">
       <div class="oj-web-applayout-footer-item oj-web-applayout-max-width">
@@ -57,4 +57,6 @@ export function Footer({ links = _DEFAULT_LINKS } : Props ) {
       </div>
     </footer>
   );
-}
+};
+
+export default Footer;

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,20 +1,22 @@
-import { h, Component, ComponentChild } from "preact";
-import * as ResponsiveUtils from "ojs/ojresponsiveutils";
 import "ojs/ojtoolbar";
 import "ojs/ojmenu";
 import "ojs/ojbutton";
 
+import * as ResponsiveUtils from "ojs/ojresponsiveutils";
+
+import { Component, ComponentChild, h } from "preact";
+
 type Props = {
-  appName: string,
-  userLogin: string
-}
+  appName: string;
+  userLogin: string;
+};
 
 type State = {
-  displayType: "all" | "icons",
-  endIconClass: string
-}
+  displayType: "all" | "icons";
+  endIconClass: string;
+};
 
-export class Header extends Component<Props, State> {
+class Header extends Component<Props, State> {
   private mediaQuery: MediaQueryList;
 
   constructor(props: Props) {
@@ -26,7 +28,7 @@ export class Header extends Component<Props, State> {
     const endIconClass = this._getEndIconClassFromDisplayType(displayType);
     this.state = {
       displayType,
-      endIconClass
+      endIconClass,
     };
   }
 
@@ -39,26 +41,40 @@ export class Header extends Component<Props, State> {
               role="img"
               class="oj-icon demo-oracle-icon"
               title="Oracle Logo"
-              alt="Oracle Logo"></span>
+              alt="Oracle Logo"
+            ></span>
             <h1
               class="oj-sm-only-hide oj-web-applayout-header-title"
-              title="Application Name">
+              title="Application Name"
+            >
               {props.appName}
             </h1>
           </div>
           <div class="oj-flex-bar-end">
-          <oj-toolbar>
-            <oj-menu-button id="userMenu" display={state.displayType} chroming="borderless">
-              <span>{props.userLogin}</span>
-              <span slot="endIcon" class={state.endIconClass}></span>
-              <oj-menu id="menu1" slot="menu">
-                <oj-option id="pref" value="pref">Preferences</oj-option>
-                <oj-option id="help" value="help">Help</oj-option>
-                <oj-option id="about" value="about">About</oj-option>
-                <oj-option id="out" value="out">Sign Out</oj-option>
-              </oj-menu>
-            </oj-menu-button>
-          </oj-toolbar>
+            <oj-toolbar>
+              <oj-menu-button
+                id="userMenu"
+                display={state.displayType}
+                chroming="borderless"
+              >
+                <span>{props.userLogin}</span>
+                <span slot="endIcon" class={state.endIconClass}></span>
+                <oj-menu id="menu1" slot="menu">
+                  <oj-option id="pref" value="pref">
+                    Preferences
+                  </oj-option>
+                  <oj-option id="help" value="help">
+                    Help
+                  </oj-option>
+                  <oj-option id="about" value="about">
+                    About
+                  </oj-option>
+                  <oj-option id="out" value="out">
+                    Sign Out
+                  </oj-option>
+                </oj-menu>
+              </oj-menu-button>
+            </oj-toolbar>
           </div>
         </div>
       </header>
@@ -70,7 +86,10 @@ export class Header extends Component<Props, State> {
   }
 
   componentWillUnmount() {
-    this.mediaQuery.removeEventListener("change", this._mediaQueryChangeListener);
+    this.mediaQuery.removeEventListener(
+      "change",
+      this._mediaQueryChangeListener
+    );
   }
 
   _mediaQueryChangeListener(mediaQuery) {
@@ -78,7 +97,7 @@ export class Header extends Component<Props, State> {
     const endIconClass = this._getEndIconClassFromDisplayType(displayType);
     this.setState({
       displayType,
-      endIconClass
+      endIconClass,
     });
   }
 
@@ -87,8 +106,10 @@ export class Header extends Component<Props, State> {
   }
 
   _getEndIconClassFromDisplayType(displayType) {
-    return displayType === "icons" ?
-      "oj-icon demo-appheader-avatar" :
-      "oj-component-icon oj-button-menu-dropdown-icon"
+    return displayType === "icons"
+      ? "oj-icon demo-appheader-avatar"
+      : "oj-component-icon oj-button-menu-dropdown-icon";
   }
 }
+
+export default Header;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-import './components/app';
+import "./components/App";


### PR DESCRIPTION
React apps tend to name components as a const and use default export (not named export)
There is a [linter rule](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md) to enforce naming.

### This PR is a refactor

1. Change typical React pattern for basic component
2. Capitalize file names (for consistency)
